### PR TITLE
Use CUDA 9.0 for TensorFlow and install TF onto r-ml image directly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -263,13 +263,12 @@ COPY --from=r-extras /usr/local/lib/R/site-library/ /usr/local/lib/R/site-librar
 RUN apt-get update \
     && apt-get upgrade -y -q \
     && apt-get install -y --no-install-recommends \
-    python-pip \
-    libpython2.7 \
-    && pip install --upgrade pip \
+    python3-dev \
+    python3-pip \
+    && pip3 install --upgrade pip \
     && hash -r \
-    && pip install virtualenv \
-    && pip install --upgrade setuptools \
-    && pip install --upgrade tensorflow-gpu keras scipy h5py pyyaml requests Pillow \
+    && pip3 install --upgrade setuptools \
+    && pip3 install --upgrade tensorflow-gpu keras \
     # install the tensorflow package and then use that to install keras
     && R -e "install.packages(c('tensorflow', 'keras'))" 
 #-e "keras::install_keras(tensorflow = 'gpu')"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,16 +11,6 @@ services:
         tty: true
         stdin_open: true
         runtime: nvidia
-    r-tensorflow:
-        build:
-            context: .
-            dockerfile: Dockerfile
-            target: r-tensorflow
-        image: landeranalytics/r-tensorflow
-        container_name: r-tensorflow
-        tty: true
-        stdin_open: true
-        runtime: nvidia
     r-xgboost:
         build:
             context: .


### PR DESCRIPTION
This is a minimum viable example that has TensorFlow installed directly onto the image and works with the GPU. 

@jaredlander for further improvements I could bump the Python up to 3. If you want to use the CUDA 9.2 image I'll also have to put back in the TensorFlow builder image to build it from source.